### PR TITLE
feat: mysql support

### DIFF
--- a/.github/workflows/rspec-tests.yml
+++ b/.github/workflows/rspec-tests.yml
@@ -44,7 +44,7 @@ jobs:
 
     services:
       postgres:
-        image: mysql:8.2-alpine
+        image: mysql:8.2
         ports: ["3306:3306"]
         env:
           MYSQL_ROOT_PASSWORD: password

--- a/.github/workflows/rspec-tests.yml
+++ b/.github/workflows/rspec-tests.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
 
     services:
-      postgres:
+      mysql:
         image: mysql:8.2
         ports: ["3306:3306"]
         env:
@@ -62,7 +62,7 @@ jobs:
         RAILS_ENV: test
         DATABASE_URL: mysql2://root:password@127.0.0.1:3306/sn_filterable_test
         DATABASE_ENCODING: utf8mb4
-      run: cd spec/dummy && bin/rails db:create db:schema:load
+      run: cd spec/dummy && bin/rails db:schema:load
     - name: Test with rspec
       env:
         RAILS_ENV: test

--- a/.github/workflows/rspec-tests.yml
+++ b/.github/workflows/rspec-tests.yml
@@ -3,8 +3,8 @@ name: Tests
 on: [push]
 
 jobs:
-  build:
-    name: RSpec
+  rspec_postgres:
+    name: RSpec (Postgres)
     runs-on: ubuntu-latest
 
     services:
@@ -31,6 +31,41 @@ jobs:
     - name: Test with rspec
       env:
         RAILS_ENV: test
+      run: bundle exec rspec
+    - name: Archive RSpec screenshots
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: rspec-screenshots
+        path: tmp/screenshots
+  rspec_mysql:
+    name: RSpec (MySQL)
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: mysql:8.2-alpine
+        ports: ["3306:3306"]
+        env:
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_DATABASE: sn_filterable_test
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.2
+        bundler-cache: true
+    - name: Setup Database
+      env:
+        RAILS_ENV: test
+        DATABASE_URL: mysql2://root:password@127.0.0.1:3306/sn_filterable_test
+      run: cd spec/dummy && bin/rails db:create db:schema:load
+    - name: Test with rspec
+      env:
+        RAILS_ENV: test
+        DATABASE_URL: mysql2://root:password@127.0.0.1:3306/sn_filterable_test
       run: bundle exec rspec
     - name: Archive RSpec screenshots
       if: always()

--- a/.github/workflows/rspec-tests.yml
+++ b/.github/workflows/rspec-tests.yml
@@ -61,11 +61,13 @@ jobs:
       env:
         RAILS_ENV: test
         DATABASE_URL: mysql2://root:password@127.0.0.1:3306/sn_filterable_test
+        DATABASE_ENCODING: utf8mb4
       run: cd spec/dummy && bin/rails db:create db:schema:load
     - name: Test with rspec
       env:
         RAILS_ENV: test
         DATABASE_URL: mysql2://root:password@127.0.0.1:3306/sn_filterable_test
+        DATABASE_ENCODING: utf8mb4
       run: bundle exec rspec
     - name: Archive RSpec screenshots
       if: always()

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sn_filterable (2.0.0)
+    sn_filterable (3.0.0)
       heroicon (~> 1)
       kaminari (~> 1)
       tailwindcss-rails (~> 2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,8 +4,6 @@ PATH
     sn_filterable (2.0.0)
       heroicon (~> 1)
       kaminari (~> 1)
-      pg (~> 1)
-      pg_search (~> 2)
       tailwindcss-rails (~> 2)
       turbo-rails (~> 2)
       view_component (~> 2)
@@ -144,6 +142,7 @@ GEM
     mini_portile2 (2.8.5)
     minitest (5.21.2)
     mutex_m (0.2.0)
+    mysql2 (0.5.6)
     net-imap (0.4.9.1)
       date
       net-protocol
@@ -161,10 +160,7 @@ GEM
     parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
-    pg (1.5.4)
-    pg_search (2.3.6)
-      activerecord (>= 5.2)
-      activesupport (>= 5.2)
+    pg (1.5.6)
     psych (5.1.2)
       stringio
     racc (1.7.3)
@@ -295,6 +291,8 @@ PLATFORMS
 DEPENDENCIES
   factory_bot_rails (~> 6)
   faker (~> 3)
+  mysql2 (~> 0.5)
+  pg (~> 1)
   rake (~> 13)
   rspec-rails (~> 6)
   rubocop-github (~> 0)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,13 @@
 version: "3"
 services:
+  mysql:
+    image: mysql:8.2
+    environment:
+      - "MYSQL_ROOT_PASSWORD=password"
+      - "MYSQL_DATABASE=sn_filterable_test"
+    ports:
+      - 3306:3306
+
   postgres:
     image: postgres:14-alpine
     ports:

--- a/lib/sn_filterable/filterable.rb
+++ b/lib/sn_filterable/filterable.rb
@@ -14,12 +14,10 @@
 # `DEFAULT_SORT`: Optional, sets the default sort of the items when no sorting parameter is set. Can be either a [String], which returns the sorting name or an [Array], where the first item is the sorting name and the second item is the sort direction (either `:asc` or `:desc`).
 #
 # @see Filtered
-require "pg_search"
 
 module SnFilterable
   module Filterable
     extend ActiveSupport::Concern
-    include PgSearch::Model
 
     class_methods do
       # Filters and sorts the model's items.

--- a/lib/sn_filterable/version.rb
+++ b/lib/sn_filterable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SnFilterable
-  VERSION = "2.0.0"
+  VERSION = "3.0.0"
 end

--- a/sn_filterable.gemspec
+++ b/sn_filterable.gemspec
@@ -29,12 +29,12 @@ Gem::Specification.new do |spec|
   # Uncomment to register a new dependency of your gem
   spec.add_dependency "heroicon", "~> 1"
   spec.add_dependency "kaminari", "~> 1"
-  spec.add_dependency "pg", "~> 1"
-  spec.add_dependency "pg_search", "~> 2"
   spec.add_dependency "tailwindcss-rails", "~> 2"
   spec.add_dependency "turbo-rails", "~> 2"
   spec.add_dependency "view_component", "~> 2"
 
+  spec.add_development_dependency "pg", "~> 1"
+  spec.add_development_dependency "mysql2", "~> 0.5"
   spec.add_development_dependency "factory_bot_rails", "~> 6"
   spec.add_development_dependency "faker", "~> 3"
   spec.add_development_dependency "rake", "~> 13"

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -16,7 +16,7 @@
 #
 default: &default
   adapter: postgresql
-  encoding: unicode
+  encoding: <%= ENV["DATABASE_ENCODING"] || "unicode" %>
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -12,10 +12,6 @@
 
 ActiveRecord::Schema.define(version: 2022_12_07_175021) do
 
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
-  enable_extension "unaccent"
-
   create_table "dummy_models", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ require "kaminari"
 require_relative "dummy/app/models/dummy_model"
 
 ActiveRecord::Base.establish_connection(
-  "postgresql://postgres:password@localhost:5432/sn_filterable_test?schema=public&connection_limit=5"
+  ENV["DATABASE_URL"] || "postgresql://postgres:password@localhost:5432/sn_filterable_test?schema=public&connection_limit=5"
 )
 
 FactoryBot.reload


### PR DESCRIPTION
This PR adds support for mysql with the `mysql2` adapter.

It is a major version bump `2.0.0 -> 3.0.0` because the `pg` and `pg_search` dependencies are now development dependencies. See the `Breaking Change` section for more details.

The rspec test suite now runs on both Postgres and MySQL databases during the test github action.

### Breaking Change

The gem no longer depends directly on the `pg_search` gem. This means
models using `pg_search_scope` must be updated to explicitly `include PgSearch::Model`.

When upgrading from 2.x to 3.x, follow these steps:

1. Ensure `pg` and `pg_search` gems are present if `pg_search_scope` is used
2. Search for usage of `include SnFilterable::Filterable` that also uses `pg_search_scope`
3. Add a line to `include PgSearch::Model` for results from step 2




