### PR TITLE
fix: extra_params is now retained when sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [Unreleased]
+## See GitHub releases for changelog
 
 ## [0.1.0] - 2022-12-05
 

--- a/app/components/sn_filterable/main_component.html.erb
+++ b/app/components/sn_filterable/main_component.html.erb
@@ -18,7 +18,7 @@
           <% if search? %>
             <%= search %>
           <% else %>
-            <div class="col-span-2 col-start-2 md:ml-48 lg:ml-64 h-12 pointer-events-auto">
+            <div class="col-span-2 xl:col-span-1 col-start-1 h-12 pointer-events-auto">
               <%= render search_field %>
             </div>
           <% end %>
@@ -83,7 +83,7 @@
         <%= render SnFilterable::FilterButtonComponent.new(filtered: @filtered, filters: @filters) %>
       </div>
       <% if @search_filter_name.present? %>
-        <div class="col-span-2 col-start-2 md:ml-64 h-12 pointer-events-none"></div>
+        <div class="col-span-2 xl:col-span-1 col-start-1 h-12 pointer-events-none"></div>
       <% end %>
     </div>
 

--- a/app/components/sn_filterable/main_component.html.erb
+++ b/app/components/sn_filterable/main_component.html.erb
@@ -18,7 +18,7 @@
           <% if search? %>
             <%= search %>
           <% else %>
-            <div class="col-span-2 xl:col-span-1 col-start-1 h-12 pointer-events-auto">
+            <div class="col-span-2 col-start-2 md:ml-48 lg:ml-64 h-12 pointer-events-auto">
               <%= render search_field %>
             </div>
           <% end %>
@@ -83,7 +83,7 @@
         <%= render SnFilterable::FilterButtonComponent.new(filtered: @filtered, filters: @filters) %>
       </div>
       <% if @search_filter_name.present? %>
-        <div class="col-span-2 xl:col-span-1 col-start-1 h-12 pointer-events-none"></div>
+        <div class="col-span-2 col-start-2 md:ml-64 h-12 pointer-events-none"></div>
       <% end %>
     </div>
 

--- a/app/components/sn_filterable/main_component.rb
+++ b/app/components/sn_filterable/main_component.rb
@@ -34,6 +34,7 @@ module SnFilterable
       @show_sidebar = show_sidebar
       @update_url_on_submit = update_url_on_submit
       @extra_params = extra_params
+      @filtered.extra_params = extra_params if extra_params.present?
     end
 
     def search_field

--- a/lib/models/filtered.rb
+++ b/lib/models/filtered.rb
@@ -7,19 +7,21 @@
 #
 # @see Filterable
 class Filtered
-  attr_accessor :items, :queries
+  attr_accessor :items, :queries, :extra_params
 
   # @param [Class] model_class The class of the ActiveRecord::Base subclass
   # @param [ActiveRecord::Relation] items The items sorted and filtered by [Filterable]
   # @param [Hash] queries A hash of the sorting / filtering parameters
   # @param [Symbol] sort_name The current sorting name
   # @param [Boolean] sort_reversed True when the current sorting order is reversed
-  def initialize(model_class, items, queries, sort_name, sort_reversed)
+  # @param [Hash] extra_params Optional hash of additional parameters to include in URLs
+  def initialize(model_class, items, queries, sort_name, sort_reversed, extra_params = {})
     @model_class = model_class
     @items = items
     @queries = queries
     @sort_name = sort_name
     @sort_reversed = sort_reversed
+    @extra_params = extra_params || {}
   end
 
   # Returns if any filters are active
@@ -161,6 +163,11 @@ class Filtered
   def modify_url_queries(url)
     uri = URI.parse(url)
     query = Rack::Utils.parse_nested_query(uri.query).deep_merge(@queries.deep_dup)
+
+    # Add extra_params to the URL
+    @extra_params.each do |key, value|
+      query[key.to_s] = value
+    end if @extra_params.present?
 
     yield(query) if block_given?
 

--- a/lib/sn_filterable/filterable.rb
+++ b/lib/sn_filterable/filterable.rb
@@ -26,8 +26,9 @@ module SnFilterable
       # @param [ActiveRecord::Relation] items Optional, the items to scope from the model
       # @param [String, Array, nil] default_sort Optional, similar to the `DEFAULT_SORT` constant, sets the default sort of items when no sorting parameter is set. Can be either a [String], which returns the sorting name or an [Array], where the first item is the sorting name and the second item is the sort direction (either `:asc` or `:desc`). Will take precedence over the `DEFAULT_SORT` constant.
       # @param [Boolean] pagination_enabled Optional, toggles pagination
+      # @param [Hash] extra_params Optional, allows for custom query parameters to be included in URLs
       # @return [Filtered] the filtered and sorted items
-      def filter(params:, items: where(nil), default_sort: nil, pagination_enabled: true)
+      def filter(params:, items: where(nil), default_sort: nil, pagination_enabled: true, extra_params: {})
         filter_params = filter_params(params)
         sort_params = sort_params(params)
         other_params = other_params(params, items)
@@ -35,7 +36,7 @@ module SnFilterable
         items = perform_filter(items, filter_params)
         items = items.page(other_params[:page]).per(other_params[:per]) if pagination_enabled
 
-        Filtered.new(self, items, generate_url_queries(filter_params, sort_params, other_params), sort_name, reverse_order)
+        Filtered.new(self, items, generate_url_queries(filter_params, sort_params, other_params), sort_name, reverse_order, extra_params)
       end
 
       private

--- a/spec/models/concerns/filterable_spec.rb
+++ b/spec/models/concerns/filterable_spec.rb
@@ -393,6 +393,14 @@ RSpec.describe SnFilterable, type: :model do  # rubocop:disable RSpec/MultipleDe
       expect(filtered.instance_variable_get(:@queries)).to eq(empty_query_hash)
       expect(filtered.instance_variable_get(:@sort_scope)).to eq(nil)
       expect(filtered.instance_variable_get(:@sort_reversed)).to eq(false)
+      expect(filtered.instance_variable_get(:@extra_params)).to eq({})
+    end
+    
+    it "correctly stores extra_params", :aggregate_failures do
+      extra_params = { "tab" => "active", "view" => "list" }
+      filtered = BasicFilterableTestModel.filter(params: ActionController::Parameters.new, extra_params: extra_params)
+
+      expect(filtered.instance_variable_get(:@extra_params)).to eq(extra_params)
     end
 
     context "with @queries" do

--- a/spec/models/filtered_spec.rb
+++ b/spec/models/filtered_spec.rb
@@ -302,5 +302,33 @@ RSpec.describe Filtered, type: :model do
 
       expect(actual_result).to eq(expected_result)
     end
+    
+    it "includes extra_params in the generated URL" do
+      filtered = BasicFilterableTestModel.filter(params: ActionController::Parameters.new({ sort: "name" }), extra_params: { "tab" => "active", "view" => "list" })
+
+      actual_result = filtered.sort_url("/", "name")
+      url = actual_result[0]
+      state = actual_result[1]
+
+      expect(state).to eq(:asc)
+      expect(url).to include("sort=name")
+      expect(url).to include("order=desc")
+      expect(url).to include("tab=active")
+      expect(url).to include("view=list")
+    end
+    
+    it "properly merges extra_params with existing URL parameters" do
+      filtered = BasicFilterableTestModel.filter(params: ActionController::Parameters.new({ sort: "name" }), extra_params: { "tab" => "active" })
+
+      actual_result = filtered.sort_url("/?existing=param", "name")
+      url = actual_result[0]
+      state = actual_result[1]
+
+      expect(state).to eq(:asc)
+      expect(url).to include("existing=param")
+      expect(url).to include("sort=name")
+      expect(url).to include("order=desc")
+      expect(url).to include("tab=active") 
+    end
   end
 end


### PR DESCRIPTION
had a use case where I needed to include additional params not part of my filter state, they were retained when I modified filter options but I realized they were lost on the sort links. This PR adds the extra_params onto the `filtered` instance so that it can be read by the helper when generating `sort_url`. Previously they were only embedded in the filter form as hidden inputs.