### PR TITLE
fix(ci): mysql tests pass

### DIFF
--- a/.github/workflows/rspec-tests.yml
+++ b/.github/workflows/rspec-tests.yml
@@ -43,7 +43,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:8.2
+        image: mysql:8.4
         ports: ["3306:3306"]
         env:
           MYSQL_ROOT_PASSWORD: password

--- a/.github/workflows/rspec-tests.yml
+++ b/.github/workflows/rspec-tests.yml
@@ -49,10 +49,10 @@ jobs:
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: sn_filterable_test
         options: >-
-          --health-cmd "mysql health ping"
-          --health-interval 10s
-          --health-timeout 10s
-          --health-retries 10
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=10s
+          --health-retries=5
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/rspec-tests.yml
+++ b/.github/workflows/rspec-tests.yml
@@ -48,6 +48,11 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: sn_filterable_test
+        options: >-
+          --health-cmd "mysql health ping"
+          --health-interval 10s
+          --health-timeout 10s
+          --health-retries 10
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The MySQL rspec tests were flaky because MySQL wasn't always ready to accept connections when running the tests. This PR adds a healthcheck for the mysql service so that it has time to initialize.